### PR TITLE
Slack APIの仕様変更に合わせて修正

### DIFF
--- a/src/hubot-slack-vote.coffee
+++ b/src/hubot-slack-vote.coffee
@@ -29,7 +29,7 @@ module.exports = (robot) ->
     votes = _.uniq(votes)
 
     msg_id = msg.message.id
-    channel = msg.message.rawMessage.channel
+    channel_id = msg.message.rawMessage.channel.id
     token = process.env.HUBOT_SLACK_TOKEN
     unless token
       robot.logger.error "HUBOT_SLACK_TOKEN does not defined."
@@ -37,17 +37,17 @@ module.exports = (robot) ->
 
     robot.logger.info votes
 
-    handle_reactions(msg, token, votes, channel, msg_id)
+    handle_reactions(msg, token, votes, channel_id, msg_id)
 
-  handle_reactions = (msg, token, votes, channel, msg_id) ->
+  handle_reactions = (msg, token, votes, channel_id, msg_id) ->
       if votes.length > 0
         vote = votes.shift()
-        reactions(msg, token, vote, channel, msg_id)
+        reactions(msg, token, vote, channel_id, msg_id)
           .then (json) ->
-            handle_reactions(msg, token, votes, channel, msg_id)
+            handle_reactions(msg, token, votes, channel_id, msg_id)
 
-  reactions = (msg, token, vote, channel, msg_id) ->
-    params = "token=#{ token }&name=#{ vote }&channel=#{ channel }&timestamp=#{ msg_id }"
+  reactions = (msg, token, vote, channel_id, msg_id) ->
+    params = "token=#{ token }&name=#{ vote }&channel=#{ channel_id }&timestamp=#{ msg_id }"
     url = "https://slack.com/api/reactions.add?#{ params }"
 
     new Promise (resolve, reject) ->


### PR DESCRIPTION
## 概要

APIの仕様が変わり、`msg.message.rawMessage.channel`がchannelのIDではなくchannelオブジェクトを返すようになった。
そのため、hubot-slack-voteが動作しなくなった（`channel_not_found`エラーが出る）。

## 変更点

- この変更に対応するために、`msg.message.rawMessage.channel.id`を用いるようにした。
- 対応する変数名を`channel`から`channel_id`に変更した

## 動作確認

![hubot](https://user-images.githubusercontent.com/3054386/31585561-e6339eee-b1fe-11e7-8d50-c6d4f8a6238d.gif)
